### PR TITLE
query parameter が握りつぶされてたのを修正

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,13 +2,15 @@ package rocket
 
 import (
 	"net/http"
-)
 
+	"github.com/naoina/denco"
+)
 
 type CtxData interface {
 	Res() *Response
 	Req() *http.Request
 	View() Renderer
+	Params() denco.Params
 
 	Render(string, RenderVars)
 	RenderText(string)
@@ -16,22 +18,23 @@ type CtxData interface {
 	RenderJSON(RenderVars)
 }
 
-
 type Context struct {
-	req *http.Request
-	res *Response
-	view Renderer
-	Stash map[string]interface{}
+	req    *http.Request
+	res    *Response
+	view   Renderer
+	params denco.Params
+	Stash  map[string]interface{}
 }
 
-func NewContext(request *http.Request, renderer Renderer) CtxData {
+func NewContext(request *http.Request, params denco.Params, renderer Renderer) CtxData {
 	c := &Context{
 		req: request,
 		res: &Response{
 			StatusCode: 404,
 		},
-		view: renderer,
-		Stash: map[string]interface{}{},
+		params: params,
+		view:   renderer,
+		Stash:  map[string]interface{}{},
 	}
 
 	return c
@@ -47,6 +50,10 @@ func (c *Context) Req() *http.Request {
 
 func (c *Context) View() Renderer {
 	return c.view
+}
+
+func (c *Context) Params() denco.Params {
+	return c.params
 }
 
 func (c *Context) RenderText(text string) {
@@ -68,5 +75,3 @@ func (c *Context) Render(tmpl string, data RenderVars) {
 	renderText := c.View().Render(tmpl, data)
 	c.Res().Body = []string{renderText}
 }
-
-

--- a/context_test.go
+++ b/context_test.go
@@ -1,8 +1,10 @@
 package rocket
 
 import (
-	"testing"
 	"net/http"
+	"testing"
+
+	"github.com/naoina/denco"
 )
 
 type MockView struct {
@@ -16,7 +18,7 @@ func (m *MockView) RenderTexts(texts []string) []string {
 	result := []string{}
 
 	for _, v := range texts {
-		result = append(result, v + v)
+		result = append(result, v+v)
 	}
 
 	return result
@@ -30,12 +32,12 @@ func (m *MockView) Render(tmpl string, data RenderVars) string {
 	return "MockView.Render(" + tmpl + ")"
 }
 
-
 func DummyContext() *Context {
 	req := &http.Request{}
 	view := &MockView{}
+	params := denco.Params{}
 
-	c := NewContext(req, view)
+	c := NewContext(req, params, view)
 
 	return c.(*Context)
 }
@@ -58,13 +60,13 @@ func TestRenderer(t *testing.T) {
 		t.Fatal("RenderTexts[1] is not powawapowawa")
 	}
 
-	c.RenderJSON(RenderVars{ "Cat": "nya" })
+	c.RenderJSON(RenderVars{"Cat": "nya"})
 
 	if c.Res().Body[0] != "MockView.RenderJSON" {
 		t.Fatal("RenderJSON does not work properly")
 	}
 
-	c.Render("powawa", RenderVars{"Cat":"mya-"})
+	c.Render("powawa", RenderVars{"Cat": "mya-"})
 
 	if c.Res().Body[0] != "MockView.Render(powawa)" {
 		t.Fatal("Render does not work properly")
@@ -86,7 +88,7 @@ func TestContextAccessors(t *testing.T) {
 		t.Fatal("something wrong on c.View()")
 	}
 
+	if c.Params() == nil {
+		t.Fatal("something wrong on c.Params()")
+	}
 }
-
-
-

--- a/webapp.go
+++ b/webapp.go
@@ -10,7 +10,7 @@ import (
 
 type Handler func(CtxData)
 
-type CtxBuilder func(req *http.Request, view Renderer) CtxData
+type CtxBuilder func(req *http.Request, params denco.Params, view Renderer) CtxData
 
 type WebApp struct {
 	router     *denco.Router
@@ -67,10 +67,10 @@ func (app *WebApp) Start(listener net.Listener) {
 }
 
 func (app *WebApp) handler(w http.ResponseWriter, req *http.Request) {
-	bind, _, _ := app.router.Lookup(req.URL.Path)
+	bind, params, _ := app.router.Lookup(req.URL.Path)
 
 	var c CtxData
-	c = app.ctxBuilder(req, bind.(*bindObject).View)
+	c = app.ctxBuilder(req, params, bind.(*bindObject).View)
 
 	bind.(*bindObject).HandleRequest(c)
 

--- a/webapp_test.go
+++ b/webapp_test.go
@@ -1,0 +1,63 @@
+package rocket
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+)
+
+type TestApp struct {
+	WebApp
+}
+
+var view *View = &View{}
+
+func newTestApp() TestApp {
+	app := TestApp{}
+	app.Init()
+	return app
+}
+
+func TestBasic(t *testing.T) {
+	app := newTestApp()
+	app.AddRoute("/", func(c CtxData) {
+		c.Res().StatusCode = http.StatusOK
+		c.RenderText("Hello World!!")
+	}, view)
+	app.BuildRouter()
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	app.handler(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("expected %v, but got %v", 200, rec.Code)
+	}
+	if rec.Body.String() != "Hello World!!" {
+		t.Errorf("expected %v, but got %v", "Hello World!!", rec.Body.String())
+	}
+}
+
+func TestQueryParams(t *testing.T) {
+	app := newTestApp()
+	app.AddRoute("/:name", func(c CtxData) {
+		c.Res().StatusCode = http.StatusOK
+		c.RenderText(fmt.Sprintf("Hello %s!!", c.Params().Get("name")))
+	}, view)
+	app.BuildRouter()
+	req, err := http.NewRequest("GET", "/powawa", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	app.handler(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("expected %v, but got %v", 200, rec.Code)
+	}
+	if rec.Body.String() != "Hello powawa!!" {
+		t.Errorf("expected %v, but got %v", "Hello powawa!!", rec.Body.String())
+	}
+}


### PR DESCRIPTION
contextにdenco.Paramsをそのまま持たせることの是非とかありそうだけど、
とりあえずそのままやったらこんな感じかなという対応をしてみた
