### PR TITLE
Fix/dispatcher init race condition

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -9,17 +9,19 @@ import (
 )
 
 func TestDispatcher(t *testing.T) {
-	d := dispatcher{}
+	d := dispatcher{view: &View{}}
 
 	var f, f2 Handler
-	f = func(ctx context.Context, c Context) {
+	f = func(ctx context.Context) {
+		c := GetContext(ctx)
 		c.RenderText("home called")
 	}
-	f2 = func(ctx context.Context, c Context) {
+	f2 = func(ctx context.Context) {
+		c := GetContext(ctx)
 		c.RenderText("patch home called")
 	}
 
-	d.AddRoute("/home", f, &View{})
+	d.AddRoute("/home", f)
 
 	bind, args, found := d.Lookup("GET", "/home")
 	if !found {
@@ -34,7 +36,7 @@ func TestDispatcher(t *testing.T) {
 		t.Fatal("invalid handler")
 	}
 
-	d.AddRouteMethod(http.MethodPatch, "/:type", f2, &View{})
+	d.AddMethodRoute(http.MethodPatch, "/:type", f2)
 	d.buildRouter() // build again
 
 	bind, args, found = d.Lookup("PATCH", "/home")

--- a/webapp_test.go
+++ b/webapp_test.go
@@ -12,17 +12,18 @@ import (
 var view *View = &View{}
 
 func prepareWebApp() *WebApp {
-	app := &WebApp{}
+	app := &WebApp{dispatcher: dispatcher{view: &View{}}}
 	app.SetContextBuilder(NewContext)
 	return app
 }
 
 func TestBasic(t *testing.T) {
 	app := prepareWebApp()
-	app.AddRoute("/", func(ctx context.Context, c Context) {
+	app.AddRoute("/", func(ctx context.Context) {
+		c := GetContext(ctx)
 		c.Res().StatusCode = http.StatusOK
 		c.RenderText("Hello World!!")
-	}, view)
+	})
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -41,15 +42,17 @@ func TestQueryArgs(t *testing.T) {
 	app := prepareWebApp()
 
 	// default handler
-	app.AddRoute("/:name", func(ctx context.Context, c Context) {
+	app.AddRoute("/:name", func(ctx context.Context) {
+		c := GetContext(ctx)
 		c.Res().StatusCode = http.StatusOK
 		c.RenderText(fmt.Sprintf("Hello %s!!", c.Args()["name"]))
-	}, view)
+	})
 	// POST handler
-	app.AddRouteMethod(http.MethodPost, "/:name", func(ctx context.Context, c Context) {
+	app.AddMethodRoute(http.MethodPost, "/:name", func(ctx context.Context) {
+		c := GetContext(ctx)
 		c.Res().StatusCode = http.StatusOK
 		c.RenderText(fmt.Sprintf("Hello POST %s!!", c.Args()["name"]))
-	}, view)
+	})
 
 	{
 		req, err := http.NewRequest("GET", "/powawa", nil)


### PR DESCRIPTION
```
fatal error: concurrent map writes
goroutine 23 [running]:
runtime.throw(0x8b5f89, 0x15)
	/usr/local/go/src/runtime/panic.go:596 +
0x95 fp=0xc420170938 sp=0xc420170918
runtime.mapassign(0x846e00, 0xc42012c450, 0xc420170ae0, 0x0)
	/usr/local/go/src/runtime/hashmap.go:589 +0x2a1 fp=0xc4201709d8 sp=0xc420170938
gopkg.in/acidlemon/rocket%2ev3.(*dispatcher).buildRouter(0xc420134200)
	/go/src/gopkg.in/acidlemon/rocket.v3/dispatcher.go:97 +0x45e fp=0xc420170bc0 sp=0xc4201709d8
gopkg.in/acidlemon/rocket%2ev3.(*dispatcher).Lookup(0xc420134200, 0xc42013a5a0, 0x4, 0xc42013a5a5, 0x9,
0x8c4e88, 0xc420138ab0, 0x20170cc0)
	/go/src/gopkg.in/acidlemon/rocket.v3/dispatcher.go:63 +0x32c fp=0xc420170c70 sp=0xc420170bc0
gopkg.in/acidlemon/rocket%2ev3.(*WebApp).Handler(0xc420134200, 0xcbac80, 0xc42018a000, 0xc420126200)
	/go/src/gopkg.in/acidlemon/rocket.v3/webapp.go:121 +0x60 fp=0xc420170ce0 sp=0xc420170c70
gopkg.in/acidlemon/rocket%2ev3.(*WebApp).ServeHTTP(0xc420134200, 0xcbac80, 0xc42018a000, 0xc420126200)
	/go/src/gopkg.in/acidlemon/rocket.v3/webapp.go:142 +0x49 fp=0xc420170d10 sp=0xc420170ce0
net/http.serverHandler.ServeHTTP(0xc42015a000, 0xcbac80, 0xc42018a000, 0xc420126200)
	/usr/local/go/src/net/http/server.go:2568 +0x92 fp=0xc420170d58 sp=0xc420170d10
net/http.(*conn).serve(0xc420152140, 0xcbb400, 0xc42013e1c0)
	/usr/local/go/src/net/http/server.go:1825 +0x612 fp=0xc420170fc8 sp=0xc420170d58
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2197 +0x1 fp=0xc420170fd0 sp=0xc420170fc8
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2668 +0x2ce
```

`fatal error: concurrent map writes` で落ちてしまうことがあったため修正
テストがpackageのapiを追従できていなかったため合わせて修正


<details>
<summary>0c27cef でのtest -race</summary>

```
> docker run --rm -v $GOPATH/src/github.com/acidlemon/rocket:/usr/src/rocket -v $GOPATH/src/github.com/naoina/denco:/go/src/github.com/naoina/denco --workdir /usr/src/rocket golang:1.10-stretch go test -vet=off -race
==================
WARNING: DATA RACE
Read at 0x00c420144db8 by goroutine 14:
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:62 +0x5c
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c420144db8 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:88 +0x95
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c420146000 by goroutine 14:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:172 +0x0
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:66 +0xbd
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c420146000 by goroutine 13:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:694 +0x0
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:97 +0x4e8
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c4201480a8 by goroutine 14:
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:66 +0xd3
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c4201480a8 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:97 +0x4fe
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c42000c0e8 by goroutine 14:
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:48 +0x54
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:66 +0x101
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c42000c0e8 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /go/src/github.com/naoina/denco/router.go:37 +0x44c
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c42000c0f0 by goroutine 14:
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:51 +0xe7
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:66 +0x101
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c42000c0f0 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /go/src/github.com/naoina/denco/router.go:37 +0x480
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c4201461f8 by goroutine 14:
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:51 +0x100
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:66 +0x101
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c4201461f8 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /go/src/github.com/naoina/denco/router.go:119 +0x3d6
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c4201480a0 by goroutine 14:
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:69 +0x332
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c4201480a0 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:97 +0x4fe
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c42000c0c8 by goroutine 14:
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:48 +0x54
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:69 +0x35d
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c42000c0c8 by goroutine 13:
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /go/src/github.com/naoina/denco/router.go:37 +0x44c
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c420146150 by goroutine 14:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:261 +0x0
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:48 +0x8f
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:69 +0x35d
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c420146150 by goroutine 13:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:694 +0x0
  github.com/naoina/denco.(*Router).Build()
      /go/src/github.com/naoina/denco/router.go:85 +0x1ba
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:98 +0x5b2
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
==================
WARNING: DATA RACE
Read at 0x00c42014a098 by goroutine 14:
  github.com/naoina/denco.(*Router).Lookup()
      /go/src/github.com/naoina/denco/router.go:48 +0xae
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:69 +0x35d
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func4()
      /usr/src/rocket/webapp_test.go:109 +0x58

Previous write at 0x00c42014a098 by goroutine 13:
  github.com/naoina/denco.(*Router).Build()
      /go/src/github.com/naoina/denco/router.go:85 +0x1d0
  _/usr/src/rocket.(*dispatcher).buildRouter()
      /usr/src/rocket/dispatcher.go:98 +0x5b2
  _/usr/src/rocket.(*dispatcher).Lookup()
      /usr/src/rocket/dispatcher.go:63 +0x384
  _/usr/src/rocket.(*WebApp).Handler()
      /usr/src/rocket/webapp.go:121 +0xb5
  _/usr/src/rocket.TestParallelRequests.func3()
      /usr/src/rocket/webapp_test.go:105 +0x58

Goroutine 14 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:108 +0x651
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 13 (running) created at:
  _/usr/src/rocket.TestParallelRequests()
      /usr/src/rocket/webapp_test.go:104 +0x60e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
--- FAIL: TestParallelRequests (0.01s)
	testing.go:730: race detected during execution of test
FAIL
exit status 1
FAIL	_/usr/src/rocket	0.024s
```

</details>

<details>
<summary> bb610e3 で修正後</summary>

```
> docker run --rm -v $GOPATH/src/github.com/acidlemon/rocket:/usr/src/rocket -v $GOPATH/src/github.com/naoina/denco:/go/src/github.com/naoina/denco --workdir /usr/src/rocket golang:1.10-stretch go test -vet=off -race
PASS
ok  	_/usr/src/rocket	1.019s
```

</details>